### PR TITLE
Attempt to get ALaCarteImpl to compile

### DIFF
--- a/ALaCarteImpl.hs
+++ b/ALaCarteImpl.hs
@@ -1,7 +1,25 @@
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveFunctor         #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE GADTs                 #-}
+
 module ALaCarteImpl where
 
 import ALaCarte
 import ALaCarteDSL
+
+import Control.Monad.State
+import Control.Monad.Reader (MonadReader, ReaderT)
+import Data.Map
+
 
 -- calculator language impl
 
@@ -48,7 +66,7 @@ calcEx1 = interpret prog
          clear
          return t
 
-calcEx1 :: StateT Int IO Int
+calcEx2 :: StateT Int IO Int
 calcEx2 = interpret prog
   where
   prog :: Free (Clear :+: Recall :+: Incr :+: Tell :+: Ask) Int

--- a/StopPayingForFreeMonads.cabal
+++ b/StopPayingForFreeMonads.cabal
@@ -22,6 +22,7 @@ library
                      , exceptions
   exposed-modules:     ALaCarte
                      , ALaCarteDSL
+                     , ALaCarteImpl
                      , Tagless
                      , Expressions
                      , Regex


### PR DESCRIPTION
Hi Mark, I noticed that ALaCarteImpl doesn't compile by default as part of the build. I added it to the .cabal file and attempted to get it to build. I'm still left with some [ambiguous instance errors](https://gist.github.com/steshaw/726db180e5f09a4da2b40b6632f4455b).

Any tips?
